### PR TITLE
Replaced deprecated StringToMobType

### DIFF
--- a/moderator.lua
+++ b/moderator.lua
@@ -2,7 +2,7 @@ function HandleSpawnMobCommand(Split,Player)
 	if Split[2] == nil then
 		Player:SendMessageInfo("Usage: /spawnmob [mobtype] [player]")
 	end
-	Mob = StringToMobType(Split[2])
+	Mob = cMonster:StringToMobType(Split[2])
 	if Mob == -1 then
 		Player:SendMessageFailure("Unknown mob type")
 	else


### PR DESCRIPTION
Errors about StringToMobType being deprecated appeared in the console every time the /spawnmob command was used. I've replaced StringToMobType with the recommended cMonster:StringToMobType.